### PR TITLE
feat(auth): add JWT login with bcrypt and protect API routes

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,8 @@ require('dotenv').config({ path: path.resolve(__dirname, '.env'), override: true
 // console.log('Influx Org:', process.env.INFLUXDB_ORG);
 // console.log('Influx Bucket:', process.env.INFLUXDB_BUCKET);
 // console.log('Influx Token:', process.env.INFLUXDB_TOKEN);
+const authRouter = require('./routes/auth');
+
 
 
 var createError = require('http-errors');
@@ -24,6 +26,9 @@ app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.use('/auth', authRouter);
+
 
 // ----- CORS (Dev) -----
 const whitelist = (process.env.CORS_WHITELIST || '')

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,23 @@
+// 用途：校验前端携带的 Bearer JWT；验证通过后把 payload 挂到 req.user。
+// 依赖：dotenv(.env) 提供 JWT_SECRET；签发在 routes/auth.js 的 /login。
+const jwt = require('jsonwebtoken');
+
+function requireAuth(req, res, next) {
+  const header = req.headers['authorization'] || '';
+  const [scheme, token] = header.split(' ');
+
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ ok: false, error: 'missing or invalid Authorization header' });
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET || 'dev-secret';
+    const payload = jwt.verify(token, secret); // { sub, role, iat, exp }
+    req.user = payload;
+    next();
+  } catch (err) {
+    return res.status(401).json({ ok: false, error: 'invalid or expired token' });
+  }
+}
+
+module.exports = requireAuth;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@influxdata/influxdb-client": "^1.35.0",
         "axios": "^1.11.0",
+        "bcryptjs": "^3.0.2",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^17.2.1",
         "express": "~4.16.1",
         "helmet": "^8.1.0",
+        "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1"
       },
       "devDependencies": {
@@ -97,6 +99,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -154,6 +165,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -337,6 +354,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -788,6 +814,97 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1105,7 +1222,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,12 +9,14 @@
   "dependencies": {
     "@influxdata/influxdb-client": "^1.35.0",
     "axios": "^1.11.0",
+    "bcryptjs": "^3.0.2",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^17.2.1",
     "express": "~4.16.1",
     "helmet": "^8.1.0",
+    "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1"
   },
   "devDependencies": {

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -4,6 +4,9 @@ const axios = require('axios');
 const { InfluxDB, Point } = require('@influxdata/influxdb-client');
 const { queryApi } = require('../services/influxClient');
 
+const requireAuth = require('../middleware/auth');
+
+
 // Resolve env var names across INFLUXDB_* and INFLUX_* prefixes
 const INFLUX_URL = process.env.INFLUXDB_URL || process.env.INFLUX_URL;
 const INFLUX_ORG = process.env.INFLUXDB_ORG || process.env.INFLUX_ORG;
@@ -30,7 +33,7 @@ const grafana = axios.create({
   timeout: 15000
 });
 
-router.get('/data', async (req, res) => {
+router.get('/data', requireAuth, async (req, res) => {
   const bucket = INFLUX_BUCKET;
   const hours = Number(req.query.h || 24);
   const measurement = (req.query.m || 'weather').trim();
@@ -75,7 +78,7 @@ router.get('/data', async (req, res) => {
 
 // ---- Influx: write points ----
 // Body: [{ measurement, tags: {...}, fields: {...}, timestamp? }, ...]
-router.post('/influx/write', async (req, res) => {
+router.post('/influx/write', requireAuth, async (req, res) => {
   try {
     const rows = Array.isArray(req.body) ? req.body : [];
     for (const r of rows) {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,134 @@
+const express = require('express');
+const router = express.Router();
+const { queryApi } = require('../services/influxClient');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const requireAuth = require('../middleware/auth');
+
+
+router.use(express.json());
+
+// 健康检查
+router.get('/ping', (req, res) => {
+  res.json({ ok: true, service: 'auth' });
+});
+
+// 调试
+router.get('/_debug/measurements', async (req, res) => {
+  try {
+    const bucket = req.query.bucket || process.env.INFLUXDB_BUCKET || process.env.INFLUX_BUCKET;
+    const flux = `
+      import "influxdata/influxdb/schema"
+      schema.measurements(bucket: "${bucket}")
+    `;
+    const list = [];
+    await new Promise((resolve, reject) => {
+      queryApi.queryRows(flux, {
+        next: (values, meta) => list.push(meta.toObject(values)._value),
+        error: reject,
+        complete: resolve,
+      });
+    });
+    res.json({ ok: true, measurements: list });
+  } catch (err) {
+    console.error('[auth/_debug/measurements] error:', err);
+    res.status(500).json({ ok: false, error: 'debug failed' });
+  }
+});
+
+// 调试
+router.get('/_debug/users-schema', async (req, res) => {
+  try {
+    const bucket = req.query.bucket || process.env.INFLUXDB_BUCKET || process.env.INFLUX_BUCKET;
+    const flux = `
+      import "influxdata/influxdb/schema"
+      union(tables: [
+        schema.measurementTagKeys(bucket: "${bucket}", measurement: "users"),
+        schema.measurementFieldKeys(bucket: "${bucket}", measurement: "users")
+      ])
+    `;
+    const keys = [];
+    await new Promise((resolve, reject) => {
+      queryApi.queryRows(flux, {
+        next: (values, meta) => keys.push(meta.toObject(values)._value),
+        error: reject,
+        complete: resolve,
+      });
+    });
+    res.json({ ok: true, keys });
+  } catch (err) {
+    console.error('[auth/_debug/users-schema] error:', err);
+    res.status(500).json({ ok: false, error: 'debug failed' });
+  }
+});
+
+// 登录：支持 bcrypt 哈希($2...) 或历史明文；成功后返回 JWT
+router.post('/login', async (req, res) => {
+  try {
+    const { username, password } = req.body || {};
+    if (!username || !password) {
+      return res.status(400).json({ ok: false, error: 'username/password required' });
+    }
+
+    const bucket = process.env.INFLUXDB_BUCKET || process.env.INFLUX_BUCKET;
+
+    const flux = `
+      from(bucket: "${bucket}")
+        |> range(start: -90d)
+        |> filter(fn: (r) => r._measurement == "users")
+        |> filter(fn: (r) => r.user == "${username}" or r.username == "${username}")
+        |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+        |> sort(columns: ["_time"], desc: true)
+        |> limit(n: 1)
+    `;
+
+    let row;
+    await new Promise((resolve, reject) => {
+      queryApi.queryRows(flux, {
+        next: (values, meta) => { row = meta.toObject(values); },
+        error: reject,
+        complete: resolve,
+      });
+    });
+
+    if (!row) return res.status(401).json({ ok: false, error: 'user not found' });
+
+    const stored = row.password || row.pass || row.pwd;
+    if (!stored) return res.status(500).json({ ok: false, error: 'user record missing password field' });
+
+    // 两种存储：1) bcrypt 哈希($2...) 2) 旧明文
+    let passOK = false;
+    if (typeof stored === 'string' && stored.startsWith('$2')) {
+      passOK = await bcrypt.compare(String(password), stored);
+    } else {
+      passOK = String(stored) === String(password);
+    }
+    if (!passOK) return res.status(401).json({ ok: false, error: 'invalid credentials' });
+
+    // 生成 JWT 7天
+    const jwtSecret = process.env.JWT_SECRET || 'dev-secret';
+    const token = jwt.sign(
+      { sub: String(username), role: row.role || 'user' },
+      jwtSecret,
+      { expiresIn: '7d' }
+    );
+
+    return res.json({
+      ok: true,
+      user: { username, role: row.role || 'user' },
+      token
+    });
+  } catch (err) {
+    console.error('[auth/login] error:', err);
+    return res.status(500).json({ ok: false, error: 'internal error' });
+  }
+});
+
+// 受保护：需要携带 Bearer JWT，成功后返回 token 里的用户信息
+router.get('/me', requireAuth, (req, res) => {
+    res.json({ ok: true, user: req.user });
+  });
+  
+
+module.exports = router;


### PR DESCRIPTION
Add routes/auth.js (login, /auth/me, debug endpoints); add middleware/auth.js; protect /api/data and /api/influx/write with requireAuth; keep bucket/env unchanged.


### Summary
- Add `backend/routes/auth.js`:
  - `POST /auth/login`: bcrypt-aware login (falls back to legacy plaintext), returns JWT (7d).
  - `GET /auth/me`: protected route, returns JWT payload.
  - Debug routes: 
    - `GET /auth/_debug/measurements?bucket=...`
    - `GET /auth/_debug/users-schema?bucket=...`
- Add `backend/middleware/auth.js`: JWT middleware (`Authorization: Bearer <token>`).
- Protect API routes:
  - `GET /api/data` → now requires JWT
  - `POST /api/influx/write` → now requires JWT
- No changes to shared config. Bucket remains `group_bucket`. Local `.env` adds `JWT_SECRET` only.

### How to test locally
```bash
# 1) Login
curl -s -X POST http://localhost:3000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"lucas","password":"123456"}'

# 2) Put returned token into env
TOKEN='<paste token here>'

# 3) Protected route
curl -s http://localhost:3000/auth/me -H "Authorization: Bearer $TOKEN"

# 4) Write & read sample data
curl -s -X POST http://localhost:3000/api/influx/write \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '[{"measurement":"weather","tags":{"location":"adelaide"},"fields":{"temp":21.5,"humidity":0.55}}]'

curl -s "http://localhost:3000/api/data?m=weather&h=1" \
  -H "Authorization: Bearer $TOKEN"
  
  
PS.  
.env changes are local-only (ignored by git). Add:

JWT_SECRET=<random-hex>
