### PR TITLE
data(samples): add weather LP + idempotent LP import script; make /api/data tag pivot optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ Connect InfluxDB via SSH tunnel
 ssh -L 8086:localhost:8086 group_project_server
 ```
 
+### Sample Data Import & Query
+#### Write Sample Data
+```bash
+ts=$(date +%s%N)
+echo "test_measurement,tag1=hello field1=123i $ts" > data/sample.lp
+
+curl -i -sS -X POST "http://localhost:8086/api/v2/write?org=${ORG}&bucket=${BUCKET}&precision=ns" \
+  -H "Authorization: Token ${TOKEN}" \
+  --data-binary @data/sample.lp
+
+#### Query Data
+curl --request POST "http://localhost:8086/api/v2/query?org=${ORG}" \
+  --header "Authorization: Token ${TOKEN}" \
+  --header 'Accept: application/csv' \
+  --header 'Content-type: application/vnd.flux' \
+  --data 'from(bucket: "group_bucket")
+  |> range(start: -1h)
+  |> filter(fn: (r) => r._measurement == "test_measurement")'
+
+#### Example Output
+...,123,test_measurement,hello
+
 ## Frontend
 
 - Node.js - v22

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "nodemon --watch backend --ext js,json --signal SIGTERM ./bin/www"
+    "dev": "nodemon --watch backend --ext js,json --signal SIGTERM ./bin/www",
+    "sample:import": "node scripts/import-lp.js"
   },
   "dependencies": {
     "@influxdata/influxdb-client": "^1.35.0",

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -2,17 +2,31 @@ const express = require('express');
 const router = express.Router();
 const { queryApi } = require('../services/influxClient');
 
+const INFLUX_URL = process.env.INFLUXDB_URL || process.env.INFLUX_URL;
+const INFLUX_ORG = process.env.INFLUXDB_ORG || process.env.INFLUX_ORG;
+const INFLUX_BUCKET = process.env.INFLUXDB_BUCKET || process.env.INFLUX_BUCKET;
+const INFLUX_TOKEN = process.env.INFLUXDB_TOKEN || process.env.INFLUX_TOKEN;
+
+
 router.get('/data', async (req, res) => {
-  const bucket = process.env.INFLUXDB_BUCKET;
+  const bucket = INFLUX_BUCKET;
   const hours = Number(req.query.h || 24);
   const measurement = (req.query.m || 'weather').trim();
+
+  // 可选：指定做 pivot 的 tag 名（例如 weather 用 tag=location）
+  const rawTag = String(req.query.tag || '').trim();
+  // 简单白名单，避免把奇怪字符拼进 Flux
+  const tag = /^[A-Za-z0-9_]+$/.test(rawTag) ? rawTag : '';
+
+  const keepCols = ['_time', '_field', '_value', ...(tag ? [tag] : [])];
+  const rowKey = tag ? `["_time","${tag}"]` : '["_time"]';
 
   const flux = `
     from(bucket: "${bucket}")
       |> range(start: -${hours}h)
       |> filter(fn: (r) => r._measurement == "${measurement}")
-      |> keep(columns: ["_time","_field","_value","location"])
-      |> pivot(rowKey:["_time","location"], columnKey: ["_field"], valueColumn: "_value")
+      |> keep(columns: ${JSON.stringify(keepCols)})
+      |> pivot(rowKey:${rowKey}, columnKey: ["_field"], valueColumn: "_value")
       |> sort(columns: ["_time"], desc: true)
       |> limit(n: 50)
   `;

--- a/backend/scripts/import-lp.js
+++ b/backend/scripts/import-lp.js
@@ -1,0 +1,66 @@
+// 作用：将 Line Protocol 文件批量写入 InfluxDB（支持固定时间戳的幂等导入）
+//
+// 用法：在仓库根目录执行
+//   node backend/scripts/import-lp.js [相对或绝对路径，默认 ../data/sample.lp]
+//
+// 行为：
+// - 读取根目录 .env 的 INFLUXDB_URL / ORG / BUCKET / TOKEN
+// - 逐行写入（忽略空行和以 # 开头的注释行）
+// - 若 LP 行包含“相同 series + 相同时间戳”，重复导入不会增加条数（Influx upsert）
+
+const fs = require('fs');
+const path = require('path');
+const { InfluxDB } = require('@influxdata/influxdb-client');
+
+//读去根目录
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+
+const INFLUX_URL    = process.env.INFLUXDB_URL || process.env.INFLUX_URL;
+const INFLUX_ORG    = process.env.INFLUXDB_ORG || process.env.INFLUX_ORG;
+const INFLUX_BUCKET = process.env.INFLUXDB_BUCKET || process.env.INFLUX_BUCKET;
+const INFLUX_TOKEN  = process.env.INFLUXDB_TOKEN || process.env.INFLUX_TOKEN;
+
+if (!INFLUX_URL || !INFLUX_ORG || !INFLUX_BUCKET || !INFLUX_TOKEN) {
+  console.error('[import-lp] Missing Influx env (URL/ORG/BUCKET/TOKEN). Check .env at repo root.');
+  process.exit(1);
+}
+
+// LP 文件路径
+const inputPathArg = process.argv[2] || '../data/sample.lp';
+const lpPath = path.resolve(__dirname, inputPathArg);
+
+(async () => {
+  try {
+    if (!fs.existsSync(lpPath)) {
+      console.error(`[import-lp] File not found: ${lpPath}`);
+      process.exit(1);
+    }
+
+    // 读取并过滤
+    const text = fs.readFileSync(lpPath, 'utf8');
+    const lines = text
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter((s) => s && !s.startsWith('#'));
+
+    if (lines.length === 0) {
+      console.log('[import-lp] No data lines after filtering comments/blank lines. Nothing to write.');
+      return;
+    }
+
+    const influx = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
+    const writeApi = influx.getWriteApi(INFLUX_ORG, INFLUX_BUCKET, 'ns');
+
+    for (const line of lines) {
+      writeApi.writeRecord(line);
+    }
+    await writeApi.close();
+
+    console.log(`[import-lp] Wrote ${lines.length} line(s) from ${lpPath}`);
+    console.log(`[import-lp] -> org="${INFLUX_ORG}", bucket="${INFLUX_BUCKET}" @ ${INFLUX_URL}`);
+    console.log('[import-lp] Note: fixed-timestamp records are idempotent (upsert, not duplicate).');
+  } catch (err) {
+    console.error('[import-lp] error:', err?.message || err);
+    process.exit(1);
+  }
+})();

--- a/data/sample.lp
+++ b/data/sample.lp
@@ -1,4 +1,1 @@
-cpu,host=server01,region=us-west usage_user=23.2,usage_system=12.1 1725552000
-cpu,host=server01,region=us-west usage_user=21.9,usage_system=11.4 1725552060
-cpu,host=server02,region=ap-south usage_user=44.3,usage_system=10.7 1725552000
-cpu,host=server02,region=ap-south usage_user=46.5,usage_system=11.2 1725552060
+test_measurement,tag1=hello field1=123.0 1755506887748694000

--- a/data/sample.lp
+++ b/data/sample.lp
@@ -1,1 +1,2 @@
 test_measurement,tag1=hello field1=123.0 1755506887748694000
+

--- a/data/sample.lp
+++ b/data/sample.lp
@@ -1,0 +1,4 @@
+cpu,host=server01,region=us-west usage_user=23.2,usage_system=12.1 1725552000
+cpu,host=server01,region=us-west usage_user=21.9,usage_system=11.4 1725552060
+cpu,host=server02,region=ap-south usage_user=44.3,usage_system=10.7 1725552000
+cpu,host=server02,region=ap-south usage_user=46.5,usage_system=11.2 1725552060

--- a/data/weather.lp
+++ b/data/weather.lp
@@ -1,0 +1,4 @@
+weather,location=adelaide temp=22.1,humidity=0.53 1735689600000000000
+weather,location=adelaide temp=23.4,humidity=0.50 1735776000000000000
+weather,location=sydney   temp=24.0,humidity=0.48 1735689600000000000
+weather,location=sydney   temp=25.2,humidity=0.46 1735776000000000000


### PR DESCRIPTION
## What
- Add sample data file: `data/weather.lp` (fixed ns timestamps; idempotent re-import).
- Add import script: `backend/scripts/import-lp.js` + npm script `sample:import`.
- Make `/api/data` pivot tag optional via `?tag=...` (compatible with measurements without `location`).

## How to use
# import test_measurement (sample.lp)
npm --prefix backend run sample:import
# import weather with tag=location
npm --prefix backend run sample:import -- ../../data/weather.lp

# query (JWT required)
curl "http://localhost:3000/api/data?m=test_measurement&h=87600" -H "Authorization: Bearer $TOKEN"
curl "http://localhost:3000/api/data?m=weather&h=87600&tag=location" -H "Authorization: Bearer $TOKEN"

## Notes
- No changes to existing env values (ORG/BUCKET/TOKEN unchanged).
- Auth flow from PR #1 remains compatible (JWT header still required for `/api/*`).
